### PR TITLE
Fix autoload cookie for auto-mode-alist

### DIFF
--- a/cypher-mode.el
+++ b/cypher-mode.el
@@ -357,8 +357,9 @@
     ))
 
 ;;;###autoload
-(add-to-list 'auto-mode-alist '("\\.cypher\\'" . cypher-mode))
-(add-to-list 'auto-mode-alist '("\\.cyp\\'" . cypher-mode))
+(progn
+  (add-to-list 'auto-mode-alist '("\\.cypher\\'" . cypher-mode))
+  (add-to-list 'auto-mode-alist '("\\.cyp\\'" . cypher-mode)))
 
 (provide 'cypher-mode)
 


### PR DESCRIPTION
This commit make auto-mode-alist for ".cyp" autoloadable.
