### PR TITLE
Declare free variable as local variable

### DIFF
--- a/cypher-mode.el
+++ b/cypher-mode.el
@@ -340,13 +340,13 @@
 
       ;;      (message "opened-blocks(%S) col-num(%S) arg-inline(%S)" opened-blocks col-num arg-inline)
 
-      (setq ctx (list :block-level opened-blocks
-                      :arg-inline arg-inline
-                      :column col-num))
+      (let ((ctx (list :block-level opened-blocks
+                       :arg-inline arg-inline
+                       :column col-num)))
 
-      (message "ctx=%S" ctx)
+        (message "ctx=%S" ctx)
 
-      ctx
+        ctx)
 
       )))
 


### PR DESCRIPTION
I got following byte-compile warnings.

```
In cypher-block-context:                                                                     
cypher-mode.el:347:25:Warning: assignment to free variable `ctx'
cypher-mode.el:349:7:Warning: reference to free variable `ctx'
```
